### PR TITLE
Blank out the board 4 of chassis to for 2023 data

### DIFF
--- a/RSRRunLineCheck.py
+++ b/RSRRunLineCheck.py
@@ -64,6 +64,8 @@ class RSRRunLineCheck():
                 else:
                     nc.hdu.process_scan()
                     nc.hdu.baseline(order=1, windows=windows, subtract=True)
+                if nc.hdu.header['Dcs']['ObsNum'].getValue() > 101107  and chassis == 2:
+                    nc.hdu.blank_frequencies({4: [(104,111)]})
                 nc.hdu.average_all_repeats(weight='sigma')
                 try:
                     integ = 2*int(nc.hdu.header.get('Bs.NumRepeats'))*int(nc.hdu.header.get('Bs.TSamp'))


### PR DESCRIPTION
Chassis 2 board 4 is not working properly since Jan 2023. 
This code blank this board for ObsNums larger than 101107.